### PR TITLE
relocate imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.2.1]
++ Relocate module imports to the top of the files
+
 ## [0.2.0] - Unreleased
 
 + Add - Call reusable CICD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,8 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.2.1]
-+ Relocate module imports to the top of the files
-
 ## [0.2.0] - Unreleased
-
++ Relocate module imports to the top of the files
 + Add - Call reusable CICD
 + Update - Remove direct dependency (`element-interface`) for PyPI release.
 + Update - Docstring PEP257 compliance #24 

--- a/element_deeplabcut/train.py
+++ b/element_deeplabcut/train.py
@@ -12,7 +12,15 @@ import yaml
 import os
 from pathlib import Path
 from element_interface.utils import find_full_path, dict_to_uuid
+from deeplabcut import train_network
+from .readers import dlc_reader
 
+try:
+    from deeplabcut.utils.auxiliaryfunctions import get_model_folder
+except ImportError:
+    from deeplabcut.utils.auxiliaryfunctions import (
+        GetModelFolder as get_model_folder,
+    )
 
 schema = dj.schema()
 _linking_module = None
@@ -209,15 +217,6 @@ class ModelTraining(dj.Computed):
         project_path, model_prefix = (TrainingTask & key).fetch1(
             "project_path", "model_prefix"
         )
-        from deeplabcut import train_network
-        from .readers import dlc_reader
-
-        try:
-            from deeplabcut.utils.auxiliaryfunctions import get_model_folder
-        except ImportError:
-            from deeplabcut.utils.auxiliaryfunctions import (
-                GetModelFolder as get_model_folder,
-            )
 
         project_path = find_full_path(get_dlc_root_data_dir(), project_path)
 

--- a/element_deeplabcut/version.py
+++ b/element_deeplabcut/version.py
@@ -1,4 +1,4 @@
 """
 Package metadata
 """
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/element_deeplabcut/version.py
+++ b/element_deeplabcut/version.py
@@ -1,4 +1,4 @@
 """
 Package metadata
 """
-__version__ = "0.2.1"
+__version__ = "0.2.0"


### PR DESCRIPTION
This PR moves the module imports from the functions to the top of the file. This is more efficient as the modules will be imported only once. In the existing configuration, modules are imported for each key in each table.