### PR TITLE
Version as env variable

### DIFF
--- a/docs/.docker/pip_requirements.txt
+++ b/docs/.docker/pip_requirements.txt
@@ -7,3 +7,4 @@ mdx-truly-sane-lists
 mkdocs-gen-files
 mkdocs-literate-nav
 mkdocs-exclude-search
+mkdocs-markdownextradata-plugin

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -14,7 +14,8 @@ services:
       - PACKAGE
       - UPSTREAM_REPO
       - MODE
-      - GOOGLE_ANALYTICS_KEY # ALSO THIS?
+      - GOOGLE_ANALYTICS_KEY 
+      - PATCH_VERSION
     volumes:
       - ../docs:/main/docs
       - ../${PACKAGE}:/main/${PACKAGE}
@@ -27,6 +28,7 @@ services:
       - |
         git config --global --add safe.directory /main
         set -e
+        export PATCH_VERSION=$$(cat /main/$${PACKAGE}/version.py | grep -oE '\d+\.\d+\.[a-z0-9]+')
         if echo "$${MODE}" | grep -i live &>/dev/null; then
             mkdocs serve --config-file ./docs/mkdocs.yaml -a 0.0.0.0:80
         elif echo "$${MODE}" | grep -iE "qa|push" &>/dev/null; then

--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -85,6 +85,7 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
 plugins:
+  - markdownextradata: {}
   - search
   # - redirects: # OPTIONAL REDIRECTS
   #     redirect_maps:
@@ -121,6 +122,7 @@ markdown_extensions:
   - pymdownx.snippets
   
 extra:
+  PATCH_VERSION: !ENV PATCH_VERSION
   generator: false # Disable watermark
   analytics:
     provider: google

--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -1,7 +1,7 @@
 # ---------------------- PROJECT SPECIFIC ---------------------------
 
 site_name: DataJoint Documentation
-site_url: http://localhost/docs/element/element-deeplabcut
+site_url: http://localhost/docs/elements/element-deeplabcut
 repo_url: https://github.com/datajoint/element-deeplabcut
 repo_name: datajoint/element-deeplabcut
 nav:

--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -92,6 +92,12 @@ plugins:
   #       "index.md": "getting_started.md"
   - mkdocstrings:
       default_handler: python
+      handlers:
+        python:
+          options:
+            members_order: source      
+            group_by_category: false
+            line_length: 88
   - gen-files:
       scripts:
       - ./src/api/make_pages.py

--- a/docs/src/citation.md
+++ b/docs/src/citation.md
@@ -8,4 +8,4 @@ Resource Identifier (RRID).
   Neurophysiology. bioRxiv. 2021 Jan 1. doi: https://doi.org/10.1101/2021.03.30.437358
 
 + DataJoint Elements ([RRID:SCR_021894](https://scicrunch.org/resolver/SCR_021894)) -
-  Element DeepLabCut (version `<Enter version number>`)
+  Element DeepLabCut (version {{ PATCH_VERSION }})

--- a/element_deeplabcut/model.py
+++ b/element_deeplabcut/model.py
@@ -37,7 +37,7 @@ def activate(
         model_schema_name (str): schema name on the database server
         create_schema (bool): when True (default), create schema in the database if it
                             does not yet exist.
-        create_tables (str): when True (default), create schema tabkes in the database
+        create_tables (str): when True (default), create schema tables in the database
                              if they do not yet exist.
         linking_module (str): a module (or name) containing the required dependencies.
 

--- a/element_deeplabcut/train.py
+++ b/element_deeplabcut/train.py
@@ -39,7 +39,7 @@ def activate(
         train_schema_name (str): schema name on the database server
         create_schema (bool): when True (default), create schema in the database if it
                             does not yet exist.
-        create_tables (str): when True (default), create schema tabkes in the database
+        create_tables (str): when True (default), create schema tables in the database
                              if they do not yet exist.
         linking_module (str): a module (or name) containing the required dependencies.
 


### PR DESCRIPTION
I couldn't get the vanilla [mkdocs implementation](https://mkdocs-macros-plugin.readthedocs.io/en/latest/pages/#configuration-variables) working

Instead I...
- added mkdocs-markdownextradata-plugin 
- added a docker compose line to export this info as env variable
- added a line in `mkdocs.yml/extra` to set a variable from the environment

I also...
- Fixed the url: `elements` -> `element`
- Added a docstring option to render in source order