### PR TITLE
[bugfix] Remove gitignore item for mkdocs notebook deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,4 +88,3 @@ workflow_deeplabcut/
 
 # docs
 /docs/site
-/docs/src/tutorials/*ipynb


### PR DESCRIPTION
[Deployed site](https://datajoint.com/docs/elements/element-deeplabcut/tutorials/01-Configure/) is not rendering notebooks. These are missing from the [gh-pages branch](https://github.com/datajoint/element-deeplabcut/tree/gh-pages/latest/tutorials). I initially added a gitignore item to prevent contributors from uploading local notebooks, but I think this preventing CICD from pushing notebooks to gh-pages branch