### PR TITLE
[bugfix] Render notebooks as tutorials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ workflow_deeplabcut/
 
 # docs
 /docs/site/
+/docs/src/tutorials/*ipynb
+/docs/mike-mkdocs*

--- a/.gitignore
+++ b/.gitignore
@@ -87,4 +87,4 @@ temp/*
 workflow_deeplabcut/
 
 # docs
-/docs/site
+/docs/site/

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -48,12 +48,12 @@ services:
             echo "INFO::mike"
             mike deploy --config-file ./docs/mkdocs.yaml -u $$(grep -oE '\d+\.\d+' /main/$${PACKAGE}/version.py) latest
             mike set-default --config-file ./docs/mkdocs.yaml latest
-            # if echo "$${MODE}" | grep -i qa &>/dev/null; then
-            #     mike serve --config-file ./docs/mkdocs.yaml -a 0.0.0.0:80
-            # elif echo "$${MODE}" | grep -i push &>/dev/null; then
-            #     echo "INFO::Push gh-pages to upstream"
-            #     git push $${UPSTREAM_REPO} gh-pages
-            # fi
+            if echo "$${MODE}" | grep -i qa &>/dev/null; then
+                mike serve --config-file ./docs/mkdocs.yaml -a 0.0.0.0:80
+            elif echo "$${MODE}" | grep -i push &>/dev/null; then
+                echo "INFO::Push gh-pages to upstream"
+                git push $${UPSTREAM_REPO} gh-pages
+            fi
         else
             echo "Unexpected mode..."
             exit 1

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -1,6 +1,7 @@
 # MODE="LIVE|QA|PUSH" PACKAGE=element_deeplabcut UPSTREAM_REPO=https://github.com/datajoint/element-deeplabcut.git HOST_UID=$(id -u) docker compose -f docs/docker-compose.yaml up --build
-#
 # navigate to http://localhost/
+#
+# Check templates: https://github.com/dj-sciops/djsciops-cicd/tree/main/docker-template
 version: "2.4"
 services:
   docs:
@@ -29,7 +30,14 @@ services:
       - |
         git config --global --add safe.directory /main
         set -e
+        export ELEMENT_NAME=$$(echo $${PACKAGE} | sed 's/element_//g')
         export PATCH_VERSION=$$(cat /main/$${PACKAGE}/version.py | grep -oE '\d+\.\d+\.[a-z0-9]+')
+        git clone https://github.com/datajoint/workflow-$${ELEMENT_NAME}.git /main/delete || true
+        if [ -d /main/delete/ ]; then
+          mv /main/delete/workflow_$${ELEMENT_NAME} /main/
+          mv /main/delete/notebooks/*ipynb /main/docs/src/tutorials/
+          rm -fR /main/delete
+        fi
         if echo "$${MODE}" | grep -i live &>/dev/null; then
             mkdocs serve --config-file ./docs/mkdocs.yaml -a 0.0.0.0:80
         elif echo "$${MODE}" | grep -iE "qa|push" &>/dev/null; then
@@ -40,12 +48,12 @@ services:
             echo "INFO::mike"
             mike deploy --config-file ./docs/mkdocs.yaml -u $$(grep -oE '\d+\.\d+' /main/$${PACKAGE}/version.py) latest
             mike set-default --config-file ./docs/mkdocs.yaml latest
-            if echo "$${MODE}" | grep -i qa &>/dev/null; then
-                mike serve --config-file ./docs/mkdocs.yaml -a 0.0.0.0:80
-            elif echo "$${MODE}" | grep -i push &>/dev/null; then
-                echo "INFO::Push gh-pages to upstream"
-                git push $${UPSTREAM_REPO} gh-pages
-            fi
+            # if echo "$${MODE}" | grep -i qa &>/dev/null; then
+            #     mike serve --config-file ./docs/mkdocs.yaml -a 0.0.0.0:80
+            # elif echo "$${MODE}" | grep -i push &>/dev/null; then
+            #     echo "INFO::Push gh-pages to upstream"
+            #     git push $${UPSTREAM_REPO} gh-pages
+            # fi
         else
             echo "Unexpected mode..."
             exit 1

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
       - MODE
       - GOOGLE_ANALYTICS_KEY 
       - PATCH_VERSION
+      - JUPYTER_PLATFORM_DIRS=1
     volumes:
       - ../docs:/main/docs
       - ../${PACKAGE}:/main/${PACKAGE}

--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -16,7 +16,7 @@ nav:
     - Automate: tutorials/04-Automate_Optional.ipynb
     - Visualization: tutorials/05-Visualization_Optional.ipynb
     - Drop Schemas: tutorials/06-Drop_Optional.ipynb
-    - Alternate Dataset: tutorials/09-AlternateDataset.ipynb  
+    - Alternate Dataset: tutorials/09-AlternateDataset.ipynb
   - Citation: citation.md
   - API: api/ # defer to gen-files + literate-nav
   - Changelog: changelog.md
@@ -118,6 +118,7 @@ plugins:
         - "*/navigation.md"
   - mkdocs-jupyter:
       ignore_h1_titles: True
+      ignore: ["*make_pages.py"]
 
 markdown_extensions:
   - attr_list

--- a/docs/src/api/make_pages.py
+++ b/docs/src/api/make_pages.py
@@ -13,20 +13,7 @@ import subprocess
 package = os.getenv("PACKAGE")
 
 element = package.split("_", 1)[1]
-if not Path(f"workflow_{element}").is_dir():
-    try:
-        subprocess.run(
-            f"git clone https://github.com/datajoint/workflow-{element.replace('_','-')}.git /main/delete".split(
-                " "
-            ),
-            check=True,
-            timeout=5,
-        )
-        os.system(f"mv /main/delete/workflow_{element} /main/")
-        os.system(f"mv /main/delete/notebooks/*ipynb /main/docs/src/tutorials/")
-        os.system("rm -fR /main/delete")
-    except subprocess.CalledProcessError:
-        pass  # no repo found
+# Previous git clone feature moved to docker compose
 
 nav = mkdocs_gen_files.Nav()
 for path in sorted(Path(package).glob("**/*.py")) + sorted(


### PR DESCRIPTION
In this PR, I ...
- Revert the `gitignore` change of my last PR. I falsely believed this was the cause of the failure
- Migrate the workflow download from the `make_pages` script to the docker compose. 
 
Thanks @yambottle for your help!

For a preview of the site, see the gh-pages deployment form my fork [here](https://cbroz1.github.io/element-deeplabcut/0.2/tutorials/01-Configure/)