### PR TITLE
Move Rest of DLC imports into make functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 
 + Fix - improve function to auto generate PoseEstimationTask
 + Update - loading DLC results handles multiple DLC output files
-+ Update - adjusted DLC related imports to be lazy
++ Update - Adopt lazy import strategy for imported DeepLabCut functions
 
 ## [0.2.1] - 2022-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and 
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.2.2] - Unreleased
+## [0.2.2] - 2022-01-17
+
 + Fix - improve function to auto generate PoseEstimationTask
 + Update - loading DLC results handles multiple DLC output files
++ Update - adjusted DLC related imports to be lazy
 
 ## [0.2.1] - 2022-12-16
 

--- a/element_deeplabcut/model.py
+++ b/element_deeplabcut/model.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from typing import Optional
 from datetime import datetime
 from element_interface.utils import find_full_path, find_root_directory
-from deeplabcut.utils.auxiliaryfunctions import get_evaluation_folder, GetScorerName
 from .readers import dlc_reader
 
 schema = dj.schema()
@@ -375,6 +374,8 @@ class Model(dj.Manual):
             prompt (bool): Optional. Prompt the user with all info before inserting.
             params (dict): Optional. If dlc_config is path, dict of override items
         """
+        from deeplabcut.utils.auxiliaryfunctions import GetScorerName # isort:skip
+
         # handle dlc_config being a yaml file
         if not isinstance(dlc_config, dict):
             dlc_config_fp = find_full_path(get_dlc_root_data_dir(), Path(dlc_config))
@@ -488,6 +489,7 @@ class ModelEvaluation(dj.Computed):
 
     def make(self, key):
         from deeplabcut import evaluate_network # isort:skip
+        from deeplabcut.utils.auxiliaryfunctions import get_evaluation_folder  # isort:skip
         """.populate() method will launch evaluation for each unique entry in Model."""
         dlc_config, project_path, model_prefix, shuffle, trainingsetindex = (
             Model & key

--- a/element_deeplabcut/train.py
+++ b/element_deeplabcut/train.py
@@ -12,13 +12,6 @@ from pathlib import Path
 from element_interface.utils import find_full_path, dict_to_uuid
 from .readers import dlc_reader
 
-try:
-    from deeplabcut.utils.auxiliaryfunctions import get_model_folder
-except ImportError:
-    from deeplabcut.utils.auxiliaryfunctions import (
-        GetModelFolder as get_model_folder,
-    )
-
 schema = dj.schema()
 _linking_module = None
 
@@ -249,6 +242,12 @@ class ModelTraining(dj.Computed):
 
     def make(self, key):
         from deeplabcut import train_network # isort:skip
+        try:
+            from deeplabcut.utils.auxiliaryfunctions import get_model_folder
+        except ImportError:
+            from deeplabcut.utils.auxiliaryfunctions import (
+                GetModelFolder as get_model_folder
+            )
 
         """Launch training for each train.TrainingTask training_id via `.populate()`."""
         project_path, model_prefix = (TrainingTask & key).fetch1(

--- a/element_deeplabcut/train.py
+++ b/element_deeplabcut/train.py
@@ -243,11 +243,11 @@ class ModelTraining(dj.Computed):
     def make(self, key):
         from deeplabcut import train_network # isort:skip
         try:
-            from deeplabcut.utils.auxiliaryfunctions import get_model_folder
+            from deeplabcut.utils.auxiliaryfunctions import get_model_folder # isort:skip
         except ImportError:
             from deeplabcut.utils.auxiliaryfunctions import (
                 GetModelFolder as get_model_folder
-            )
+            ) # isort:skip
 
         """Launch training for each train.TrainingTask training_id via `.populate()`."""
         project_path, model_prefix = (TrainingTask & key).fetch1(

--- a/element_deeplabcut/version.py
+++ b/element_deeplabcut/version.py
@@ -1,4 +1,4 @@
 """
 Package metadata
 """
-__version__ = "0.2.1"
+__version__ = "0.2.2"


### PR DESCRIPTION
- CUDA issues between torch package required by certain steps in DLC are still occurring. 
- Currently solution is to move all imports into the make functions while they are used. This will allow for importing of workflow.pipeline in the Sabatini ephys (spike-sorting-worker), which requires a different CUDA version(11.0.3) than is required by DLC(11.2).  