### PR TITLE
update setup and model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         "datajoint>=0.13",
         "graphviz",
         "pydot",
-        "networkx==2.8.2",
         "ipykernel",
         "ipywidgets",
     ],


### PR DESCRIPTION
- [x] Update the setup to remove the `networkx` dependency.
- [ ] Modify `model.py` to enable automatic registration of the trained model in the `model` table, eliminating the need to use `insert_new_model` for registering the model generated after the training process.



