### PR TITLE
update `setup.py` to fix conflicting dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         "datajoint>=0.13",
         "graphviz",
         "pydot",
-        "networkx==2.8.2",
         "ipykernel",
         "ipywidgets",
     ],


### PR DESCRIPTION
`vathes-team_dlc` installation pointed requirements to my fork and able to get around of this conflict: 
`ERROR: Cannot install datajoint==0.14.1, element-deeplabcut[dlc-default]==0.2.9 and element-lab because these package versions have conflicting dependencies.`

This update fixes that issue as now there is no more conflict between `networkx` and `datajoint`.