### PR TITLE
Update `snapshotindex` and `latest_snapshot` designation

### DIFF
--- a/element_deeplabcut/train.py
+++ b/element_deeplabcut/train.py
@@ -326,15 +326,17 @@ class ModelTraining(dj.Computed):
         # Here, we mean most recently generated
         
         # `snapshotindex` refers to the file index of the snapshot generated
-        # The most recent snapshot index will be the number of snapshots
+        # The most recent snapshot index will be the number of snapshots - 1
+        # because it is an index
 
         # update snapshotindex in the config
-        dlc_config["snapshotindex"] = len(snapshots)
+        latest_snapshot = len(snapshots)-1
+        dlc_config["snapshotindex"] = latest_snapshot
         edit_config(
             dlc_cfg_filepath,
-            {"snapshotindex": len(snapshots)},
+            {"snapshotindex": latest_snapshot},
         )
 
         self.insert1(
-            {**key, "latest_snapshot": len(snapshots), "config_template": dlc_config}
+            {**key, "latest_snapshot": latest_snapshot, "config_template": dlc_config}
         )

--- a/element_deeplabcut/train.py
+++ b/element_deeplabcut/train.py
@@ -321,22 +321,28 @@ class ModelTraining(dj.Computed):
         except KeyboardInterrupt:  # Instructions indicate to train until interrupt
             print("DLC training stopped via Keyboard Interrupt")
 
-        snapshots = list(model_train_folder.glob("*index*"))
+        snapshots = sorted(list(model_train_folder.glob("*index*")))
+        max_modified_time = 0
         # DLC goes by snapshot magnitude when judging 'latest' for evaluation
         # Here, we mean most recently generated
-        
-        # `snapshotindex` refers to the file index of the snapshot generated
-        # The most recent snapshot index will be the number of snapshots - 1
-        # because it is an index
+        for snapshot in snapshots:
+            modified_time = os.path.getmtime(snapshot)
+            if modified_time > max_modified_time:
+                latest_snapshot_file = snapshot
+                latest_snapshot = int(latest_snapshot_file.stem[9:])
+                max_modified_time = modified_time
 
         # update snapshotindex in the config
-        latest_snapshot = len(snapshots)-1
-        dlc_config["snapshotindex"] = latest_snapshot
+        snapshotindex = snapshots.index(latest_snapshot_file)
+        
+        dlc_config["snapshotindex"] = snapshotindex
         edit_config(
             dlc_cfg_filepath,
-            {"snapshotindex": latest_snapshot},
+            {"snapshotindex": snapshotindex},
         )
 
         self.insert1(
             {**key, "latest_snapshot": latest_snapshot, "config_template": dlc_config}
         )
+
+

--- a/element_deeplabcut/train.py
+++ b/element_deeplabcut/train.py
@@ -322,22 +322,19 @@ class ModelTraining(dj.Computed):
             print("DLC training stopped via Keyboard Interrupt")
 
         snapshots = list(model_train_folder.glob("*index*"))
-        max_modified_time = 0
         # DLC goes by snapshot magnitude when judging 'latest' for evaluation
         # Here, we mean most recently generated
-        for snapshot in snapshots:
-            modified_time = os.path.getmtime(snapshot)
-            if modified_time > max_modified_time:
-                latest_snapshot = int(snapshot.stem[9:])
-                max_modified_time = modified_time
+        
+        # `snapshotindex` refers to the file index of the snapshot generated
+        # The most recent snapshot index will be the number of snapshots
 
         # update snapshotindex in the config
-        dlc_config["snapshotindex"] = latest_snapshot
+        dlc_config["snapshotindex"] = len(snapshots)
         edit_config(
             dlc_cfg_filepath,
-            {"snapshotindex": latest_snapshot},
+            {"snapshotindex": len(snapshots)},
         )
 
         self.insert1(
-            {**key, "latest_snapshot": latest_snapshot, "config_template": dlc_config}
+            {**key, "latest_snapshot": len(snapshots), "config_template": dlc_config}
         )


### PR DESCRIPTION
- Update `snapshotindex` to be the file index from where the snapshot files are generated, as opposed to the number(iterations) present in the filename.  