### PR TITLE
add plotting function to call dlc PlottingResults on PoseEstimation results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and 
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.3.3] - TBD
+
++ Add - Plotting with `deeplabcut.utils.plotting.PlottingResults`
+
 ## [0.3.2] - 2024-09-09
 
 + Fix - Save config file to output directory as `dj_dlc_config`

--- a/element_deeplabcut/plotting/dlc_plots.py
+++ b/element_deeplabcut/plotting/dlc_plots.py
@@ -1,0 +1,36 @@
+def plotting_results(pose_estimation_key: dict):
+    """
+    Wrapper for deeplabcut.utils.plotting.PlottingResults,
+        using dlc_result object from `dlc_reader.PoseEstimation`
+    Args:
+        pose_estimation_key (dict): PoseEstimation key
+
+    Returns:
+        plots_dir (Path): Path to the folder containing the plots
+    """
+    import deeplabcut
+    from element_deeplabcut import dlc_reader, model
+
+    output_dir = (model.PoseEstimationTask & pose_estimation_key).fetch1(
+        "pose_estimation_output_dir"
+    )
+    output_dir = model.find_full_path(model.get_dlc_root_data_dir(), output_dir)
+
+    dlc_result = dlc_reader.PoseEstimation(output_dir)
+
+    plots_dir = output_dir / "plots"
+    plots_dir.mkdir(exist_ok=True)
+
+    deeplabcut.utils.plotting.PlottingResults(
+        tmpfolder=plots_dir,
+        Dataframe=dlc_result.rawdata,
+        cfg=dlc_result.yml,
+        bodyparts2plot=dlc_result.body_parts.to_list(),
+        individuals2plot="",
+        showfigures=False,
+        suffix=".png",
+        resolution=100,
+        linewidth=1.0,
+    )
+
+    return plots_dir

--- a/element_deeplabcut/version.py
+++ b/element_deeplabcut/version.py
@@ -2,4 +2,4 @@
 Package metadata
 """
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"


### PR DESCRIPTION
- For PoseEstimation results, call `deeplabcut.utils.plotting.PlottingResults` to generate 4 plots (png): trajectory, plot, hist, plot-likelihood