### PR TITLE
feat(pytorch_dlc): support the latest DLC with pytorch engine

### DIFF
--- a/element_deeplabcut/version.py
+++ b/element_deeplabcut/version.py
@@ -2,4 +2,4 @@
 Package metadata
 """
 
-__version__ = "0.3.3"
+__version__ = "0.4.0"

--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,8 @@ setup(
             "element-interface @ git+https://github.com/datajoint/element-interface.git",
         ],
         "tests": ["pytest", "pytest-cov", "shutils"],
+        "dlc-pytorch": [
+            "deeplabcut @ git+https://github.com/DeepLabCut/DeepLabCut.git@pytorch_dlc"
+        ],
     },
 )


### PR DESCRIPTION
This PR adds support for using pytorch as another engine (tensorflow still the default).
DeepLabCut still has this work on a separate branch (`pytorch_dlc`)

This PR does introduce a new non-primary attribute `engine` to the table `Model`. For users with the `Model` table already created, an `alter` is needed on this `Model` table.